### PR TITLE
Stop recording on dispose

### DIFF
--- a/uca-net-camera.c
+++ b/uca-net-camera.c
@@ -429,7 +429,21 @@ uca_net_camera_get_property (GObject *object,
 static void
 uca_net_camera_dispose (GObject *object)
 {
-    g_object_unref (UCA_NET_CAMERA_GET_PRIVATE (object)->client);
+    UcaNetCameraPrivate *priv;
+
+    priv = UCA_NET_CAMERA_GET_PRIVATE (object);
+
+    if (uca_camera_is_recording (UCA_CAMERA (object))) {
+        GError *error = NULL;
+
+        uca_camera_stop_recording (UCA_CAMERA (object), &error);
+        if (error != NULL) {
+            g_warning ("Could not stop recording: %s", error->message);
+            g_error_free (error);
+        }
+    }
+
+    g_clear_object (&priv->client);
     G_OBJECT_CLASS (uca_net_camera_parent_class)->dispose (object);
 }
 

--- a/uca-net-camera.c
+++ b/uca-net-camera.c
@@ -416,6 +416,11 @@ uca_net_camera_get_property (GObject *object,
         return;
     }
 
+    if (priv->client == NULL) {
+        g_debug ("Not requesting property becuase connection has been already closed");
+        return;
+    }
+
     /* handle remote props */
     connection = connect_socket (priv, &error);
     name = g_param_spec_get_name (pspec);

--- a/uca-net-camera.c
+++ b/uca-net-camera.c
@@ -603,6 +603,8 @@ uca_net_camera_constructed (GObject *object)
 
         g_object_unref (connection);
     }
+
+    G_OBJECT_CLASS (uca_net_camera_parent_class)->constructed (object);
 }
 
 static void

--- a/uca-net-camera.c
+++ b/uca-net-camera.c
@@ -41,8 +41,6 @@ GQuark uca_net_camera_error_quark ()
 
 enum {
     PROP_HOST = N_BASE_PROPERTIES,
-    IS_RECORDING,
-    IS_READOUT,
     N_PROPERTIES
 };
 

--- a/ucad.c
+++ b/ucad.c
@@ -230,6 +230,7 @@ handle_get_property_request (GSocketConnection *connection, UcaCamera *camera, g
     reply.type = request->type;
     strncpy (reply.property_value, g_value_get_string (&str_value), sizeof (reply.property_value));
     send_reply (connection, &reply, sizeof (reply), error);
+    g_debug ("Getting `%s'=`%s'", request->property_name, reply.property_value);
     g_value_unset (&str_value);
 }
 


### PR DESCRIPTION
to comply with https://github.com/ufo-kit/libuca/pull/44
Since our connection is destroyed on dispose we must make sure that when the parent's dispose is called the camera is already not recording, so we stop it in our dispose. Then, we can just return false in the get_propoerty in case client has been destroyed already.